### PR TITLE
`optimaltree` hangs on edge case with all costs equal to 1

### DIFF
--- a/src/indexnotation/optimaltree.jl
+++ b/src/indexnotation/optimaltree.jl
@@ -90,8 +90,8 @@ function computecost(allcosts, ind1::BitSet, ind2::BitSet)
 end
 
 function computemaxcost(allcosts, indexsets)
-    if length(indexsets) == 1
-        maxcost = one(etltype(allcosts))
+    if length(indexsets) ≤ 1
+        maxcost = one(eltype(allcosts))
     else
         maxcost = zero(eltype(allcosts))
         s1 = indexsets[1]

--- a/src/indexnotation/optimaltree.jl
+++ b/src/indexnotation/optimaltree.jl
@@ -4,10 +4,11 @@ function optimaltree(network, optdata::Dict; verbose::Bool=false)
     numindices = length(allindices)
     costtype = valtype(optdata)
     allcosts = costtype[get(optdata, i, one(costtype)) for i in allindices]
-    maxcost = addcost(mulcost(reduce(mulcost, allcosts; init=one(costtype)),
-                              maximum(allcosts)), one(costtype))
-    # add one for type stability: Power -> Poly
-    # and for dealing with cases where all sizes are 1 -> maxcost = 2
+    maxcost = max(mulcost(reduce(mulcost, allcosts; init=one(costtype)),
+                          maximum(allcosts)), costtype(length(network) - 1))
+    # add zero for type stability: Power -> Poly
+    maxcost = addcost(maxcost, zero(costtype))
+
     tensorcosts = Vector{costtype}(undef, numtensors)
     for k in 1:numtensors
         tensorcosts[k] = mapreduce(i -> get(optdata, i, one(costtype)), mulcost, network[k];

--- a/src/indexnotation/optimaltree.jl
+++ b/src/indexnotation/optimaltree.jl
@@ -5,7 +5,9 @@ function optimaltree(network, optdata::Dict; verbose::Bool=false)
     costtype = valtype(optdata)
     allcosts = costtype[get(optdata, i, one(costtype)) for i in allindices]
     maxcost = addcost(mulcost(reduce(mulcost, allcosts; init=one(costtype)),
-                              maximum(allcosts)), zero(costtype)) # add zero for type stability: Power -> Poly
+                              maximum(allcosts)), one(costtype))
+    # add one for type stability: Power -> Poly
+    # and for dealing with cases where all sizes are 1 -> maxcost = 2
     tensorcosts = Vector{costtype}(undef, numtensors)
     for k in 1:numtensors
         tensorcosts[k] = mapreduce(i -> get(optdata, i, one(costtype)), mulcost, network[k];

--- a/test/tensoropt.jl
+++ b/test/tensoropt.jl
@@ -58,8 +58,13 @@ end
 
 @testset "Issue #206" begin
     # https://github.com/Jutho/TensorOperations.jl/issues/206
-    network = [[:a, :b], [:a], [:b]]
-    opt_data = Dict(:a => 1, :b => 1)
+    network = [[Symbol(1), Symbol(2)], [Symbol(1)], [Symbol(2)]]
+    opt_data = Dict(Symbol(1) => 1, Symbol(2) => 1)
     tree, cost = TensorOperations.optimaltree(network, opt_data)
     @test cost == 2
+
+    network = network = [[:a, :b, :c], [:a], [:b], [:c]]
+    opt_data = Dict(:a => 1, :b => 1, :c => 1)
+    tree, cost = TensorOperations.optimaltree(network, opt_data)
+    @test cost == 3
 end

--- a/test/tensoropt.jl
+++ b/test/tensoropt.jl
@@ -55,3 +55,11 @@
                                          1,
                                          0, 0, 0, 3, 0, 3, 2, 0, 2, 4])
 end
+
+@testset "Issue #206" begin
+    # https://github.com/Jutho/TensorOperations.jl/issues/206
+    network = [[:a, :b], [:a], [:b]]
+    opt_data = Dict(:a => 1, :b => 1)
+    tree, cost = TensorOperations.optimaltree(network, opt_data)
+    @test cost == 2
+end


### PR DESCRIPTION
Fix for #206 

@Jutho correct me if I'm wrong, but I think what is going on here is that the initial guess for the `maxcost` is wrong for these cases:
From what I can tell we use:

$$(\prod_i \chi_i) * \max_i(\chi_i)$$

Which evaluates to `1` in this case, while the actual maximal cost would be `(n-1) * 1` with `n` the number of tensors.
I patched the specific case of all sizes equal to 1, but I am not sure if this now captures all possible problems. (I'm also not entirely sure where the initial formula came from?)

I could also replace this `maxcost` with the cost of simply multiplying in the order that is supplied, but I'm not sure what the implications are for the algorithm.