### PR TITLE
[Fix] `makeblascontractable` should return blascontractable objects.

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -32,7 +32,7 @@ jobs:
         #
         # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1"))'
           julia  -e 'using JuliaFormatter; format(".", verbose=true)'
       - name: Format check
         run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorOperations"
 uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "5.2.0"
+version = "5.2.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/implementation/blascontract.jl
+++ b/src/implementation/blascontract.jl
@@ -84,8 +84,9 @@ end
 function makeblascontractable(A, pA, TC, backend, allocator)
     flagA = isblascontractable(A, pA) && eltype(A) == TC
     if !flagA
-        A_ = tensoralloc_add(TC, A, pA, false, Val(true), allocator)
-        Anew = SV(A_, size(A_), strides(A_), 0, A.op)
+        conjA = A.op === conj
+        A_ = tensoralloc_add(TC, A, pA, conjA, Val(true), allocator)
+        Anew = SV(A_)
         Anew = tensoradd!(Anew, A, pA, false, One(), Zero(), backend, allocator)
         pAnew = trivialpermutation(pA)
     else

--- a/src/implementation/blascontract.jl
+++ b/src/implementation/blascontract.jl
@@ -84,8 +84,7 @@ end
 function makeblascontractable(A, pA, TC, backend, allocator)
     flagA = isblascontractable(A, pA) && eltype(A) == TC
     if !flagA
-        conjA = A.op === conj
-        A_ = tensoralloc_add(TC, A, pA, conjA, Val(true), allocator)
+        A_ = tensoralloc_add(TC, A, pA, false, Val(true), allocator)
         Anew = SV(A_)
         Anew = tensoradd!(Anew, A, pA, false, One(), Zero(), backend, allocator)
         pAnew = trivialpermutation(pA)

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -558,6 +558,7 @@ end
         end
 
         vA = view(A, 1:2, 1:2, 1:2, 1:2)
+        p = ((1, 2), (3, 4))
         @test !isblascontractable(vA, p)
         Anew, pnew, flag = makeblascontractable(vA, p, ComplexF64, backend, allocator)
         @test !flag

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -532,6 +532,7 @@ end
     @testset "methods for StridedBLAS" begin
         using TensorOperations: isblascontractable, isblasdestination, makeblascontractable,
                                 StridedBLAS, DefaultAllocator
+        using Strided
         backend = StridedBLAS()
         allocator = DefaultAllocator()
 


### PR DESCRIPTION
I was doing some benchmarking with the `StridedBLAS` backend, and found some interesting results in the profiler: somehow I was hitting the [`Strided.__mul!`](https://github.com/Jutho/Strided.jl/blob/f8a0514bbcf837f87186c8383dba0c35f7822f0f/src/linalg.jl#L130) generic implementation instead of the `gemm` one from BLAS, and it turns out that for conjugated inputs, the `makeblascontractable` function doesn't actually return a blascontractable object. The result is a slow fallback implementation instead of the actual BLAS call.

The current fix seems easy enough, although it's not the only option: in principle we could retain the `A.op` while permuting such that everything fuses and the second stride is 1, but I'm not sure if this would then make a lot of difference performance-wise?

I'm not sure if this is something we should add explicit tests for either. (It's not too hard to check that the output of `makeblascontractable` satisfies `isblascontractable`, which is also how I found this "bug").