### PR TITLE
Bump dependency compat and try using TO on newer CUDA/cuTENSOR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorOperations"
 uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "5.3.0"
+version = "5.4.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -32,7 +32,7 @@ TensorOperationscuTENSORExt = ["cuTENSOR", "CUDA"]
 [compat]
 Aqua = "0.6, 0.7, 0.8"
 Bumper = "0.6, 0.7"
-CUDA = "5.4.0"
+CUDA = "5"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
 DynamicPolynomials = "0.5"
@@ -49,7 +49,7 @@ StridedViews = "0.3, 0.4"
 Test = "1"
 TupleTools = "1.6"
 VectorInterface = "0.4.1,0.5"
-cuTENSOR = "2.1.1"
+cuTENSOR = "2"
 julia = "1.8"
 
 [extras]


### PR DESCRIPTION
This actually failed for me locally which is interesting/concerning. It would be great to support newer cuTENSOR and `CUDA.jl` as a lot of updates have happened there.