### PR TITLE
Do not inform user during precompilation

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -123,18 +123,4 @@ if workload_enabled()
             precompile(tensoralloc_contract, (T, A, pA, Bool, B, pB, Bool, pAB, Val{false}))
         end
     end
-else
-    @info """
-    TensorOperations can optionally be instructed to precompile several functions, which can be used to reduce the time to first execution (TTFX).
-    This is disabled by default as this can take a while on some machines, and is only relevant for contraction-heavy workloads.
-
-    To enable or disable precompilation, you can use the following script:
-
-    ```julia
-    using TensorOperations, Preferences
-    set_preferences!(TensorOperations, "precompile_workload" => true; force=true)
-    ```
-
-    This will create a `LocalPreferences.toml` file next to your current `Project.toml` file to store this setting in a persistent way.
-    """
 end


### PR DESCRIPTION
The current approach seems to have multiple disadvantages:
- If the user only got `TensorOperatoins.jl` as a indirect dependency, the information seems to be completely useless
- It's untypical to give information about a package during precompilation. That's what Readmes, docstrings or similar things are for
- The user can't deactivate it. If I read the code correctly, even setting the preference to false would print the warning again

So until a better solution is found, I think it makes sense to deactivate the precompile output.