### PR TITLE
Special case tensoradd! to bypass PermutedDimsArray for Diagonals

### DIFF
--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -28,11 +28,13 @@ function tensoradd!(
     end
     return C
 end
+
+# needed to avoid ambiguity error
 function tensoradd!(
         C::AbstractArray,
         A::Diagonal, pA::Index2Tuple, conjA::Bool,
         α::Number, β::Number,
-        backend, allocator = DefaultAllocator()
+        ::BaseView, allocator = DefaultAllocator()
     )
     argcheck_tensoradd(C, A, pA)
     dimcheck_tensoradd(C, A, pA)
@@ -65,8 +67,13 @@ function tensoradd!(
 
     # can we assume that C is mutable?
     # is there more functionality in base that we can use?
-    Atemp = tensoralloc_add(eltype(A), A, pA, conjA, Val(true), allocator)
-    Ã = permutedims!(Atemp, A, linearize(pA))
+    Ã = if !isa(A, Diagonal)
+        Atemp = tensoralloc_add(eltype(A), A, pA, conjA, Val(true), allocator)
+        permutedims!(Atemp, A, linearize(pA))
+    else
+        Atemp = nothing
+        A
+    end
     if conjA
         if iszero(β)
             C .= α .* conj.(Ã)
@@ -80,7 +87,7 @@ function tensoradd!(
             C .= β .* C .+ α .* Ã
         end
     end
-    tensorfree!(Atemp, allocator)
+    !isa(A, Diagonal) && tensorfree!(Atemp, allocator)
     return C
 end
 

--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -32,7 +32,7 @@ function tensoradd!(
         C::AbstractArray,
         A::Diagonal, pA::Index2Tuple, conjA::Bool,
         α::Number, β::Number,
-        ::BaseView, allocator = DefaultAllocator()
+        backend, allocator = DefaultAllocator()
     )
     argcheck_tensoradd(C, A, pA)
     dimcheck_tensoradd(C, A, pA)

--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -30,6 +30,32 @@ function tensoradd!(
 end
 function tensoradd!(
         C::AbstractArray,
+        A::Diagonal, pA::Index2Tuple, conjA::Bool,
+        α::Number, β::Number,
+        ::BaseView, allocator = DefaultAllocator()
+    )
+    argcheck_tensoradd(C, A, pA)
+    dimcheck_tensoradd(C, A, pA)
+
+    # can we assume that C is mutable?
+    # is there more functionality in base that we can use?
+    if conjA
+        if iszero(β)
+            C .= α .* conj.(A)
+        else
+            C .= β .* C .+ α .* conj.(A)
+        end
+    else
+        if iszero(β)
+            C .= α .* A
+        else
+            C .= β .* C .+ α .* A
+        end
+    end
+    return C
+end
+function tensoradd!(
+        C::AbstractArray,
         A::AbstractArray, pA::Index2Tuple, conjA::Bool,
         α::Number, β::Number,
         ::BaseCopy, allocator = DefaultAllocator()

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -58,6 +58,32 @@ bufferallocator(::Type{ROCArray}; kwargs...) = TensorOperations.AMDBufferAllocat
             tensoradd!(c, a, (p, ()), true, α, β, backend)
         end
     end
+    # test Diagonal special case
+    sz = (8, 8)
+    p = (2, 1)
+    diag_backends = [BaseCopy(), BaseView()]
+    for backend in diag_backends, T in (Float32, ComplexF32)
+        A = Diagonal(randn(T, sz[1]))
+        C = randn(T, TupleTools.getindices(sz, p))
+
+        @test compare(AT, C, A) do c, a
+            tensoradd!(c, a, (p, ()), false, One(), Zero(), backend)
+        end
+
+        α = rand(T)
+        @test compare(AT, C, A) do c, a
+            tensoradd!(c, a, (p, ()), false, α, Zero(), backend)
+        end
+
+        β = rand(T)
+        @test compare(AT, C, A) do c, a
+            tensoradd!(c, a, (p, ()), false, α, β, backend)
+        end
+
+        T <: Real || @test compare(AT, C, A) do c, a
+            tensoradd!(c, a, (p, ()), true, α, β, backend)
+        end
+    end
 end
 
 @testset "tensortrace! ($AT)" for AT in ATs


### PR DESCRIPTION
For GPU-backed `StridedViews`, we were having problems because TensorOperations was calling into the **CPU** broadcasting functionality, since GPUArrays.jl couldn't detect that a `PermutedDimsArray` wrapped around `Diagonal` wrapped around a GPU array is a GPU array. But permuting a diagonal is silly, because it's effectively a no-op. So here I special-cased `tensoradd!` to avoid the extra wrapper, and it seems to make the GPU code happy.