### PR TITLE
Release v5.8.0

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -2,8 +2,8 @@
 	author  = {Lukas Devos <lukas.devos@ugent.be>, Maarten Van Damme <maartenvd1994@gmail.com>, Jutho Haegeman <jutho.haegeman@ugent.be> and contributors},
 	title   = {TensorOperations.jl},
 	url     = {https://github.com/Jutho/TensorOperations.jl},
-	version = {v4.0.7},
+	version = {v5.8.0},
 	doi		= {10.5281/zenodo.3245496},
-	year    = {2023},
-	month   = {10}
+	year    = {2026},
+	month   = {8}
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorOperations"
 uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
-version = "5.7.0"
+version = "5.8.0"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
             "man/implementation.md",
             "man/precompilation.md",
         ],
+        "Changelog" => "changelog.md",
         "Index" => "index/index.md",
     ],
     checkdocs = :public

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/QuantumKitHub/TensorOperations.jl/compare/v5.8.0...HEAD)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+## [5.8.0](https://github.com/QuantumKitHub/TensorOperations.jl/compare/v5.7.0...v5.8.0) - 2026-08-13
+
+### Added
+
+- `TBLISBackend`, an opt-in backend routing `tensoradd!`, `tensortrace!` and `tensorcontract!` through [TBLIS.jl](https://github.com/QuantumKitHub/TBLIS.jl), available as a package extension. This supersedes the standalone TensorOperationsTBLIS.jl ([#290](https://github.com/QuantumKitHub/TensorOperations.jl/pull/290)).
+- Buffer-backed allocators for GPU array types, which serve temporaries from a single preallocated device buffer: `CUDABufferAllocator`, `AMDBufferAllocator` and `JLBufferAllocator` ([#293](https://github.com/QuantumKitHub/TensorOperations.jl/pull/293), [#295](https://github.com/QuantumKitHub/TensorOperations.jl/pull/295), [#296](https://github.com/QuantumKitHub/TensorOperations.jl/pull/296)).
+
+### Fixed
+
+- Plan leak in the cuTENSOR implementation of `tensortrace!`, which retained the reduction workspace until finalization ([#294](https://github.com/QuantumKitHub/TensorOperations.jl/pull/294)).
+
+### Performance
+
+- `tensoradd!` bypasses `PermutedDimsArray` for `Diagonal` arguments ([#297](https://github.com/QuantumKitHub/TensorOperations.jl/pull/297)).


### PR DESCRIPTION
## TensorOperations.jl v5.8.0

Adds a TBLIS-backed contraction backend and buffer-based allocators for GPU arrays.

### Highlights

- **`TBLISBackend`** — an opt-in backend routing `tensoradd!`, `tensortrace!` and `tensorcontract!` through [TBLIS.jl](https://github.com/QuantumKitHub/TBLIS.jl), contracting strided tensors in place rather than reshaping them into matrices. Loaded as a package extension; supersedes the standalone TensorOperationsTBLIS.jl (#290).
- **GPU buffer allocators** — `CUDABufferAllocator`, `AMDBufferAllocator` and `JLBufferAllocator` serve temporaries from a single preallocated device buffer (#293, #295, #296).
- **cuTENSOR `tensortrace!` plan leak fixed** — the reduction workspace was previously only reclaimed by the finalizer; 10⁴ traces grew live device memory by 1.22 GiB, now 9.8 KiB (#294).
- **Better `Diagonal` adds** — `tensoradd!` bypasses `PermutedDimsArray` for `Diagonal` arguments (#297).

### Full Changelog

See [CHANGELOG](https://github.com/QuantumKitHub/TensorOperations.jl/blob/main/docs/src/changelog.md#580---2026-08-13) for the complete list of changes.
